### PR TITLE
Add thumbnail URL support for playlists

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -266,6 +266,7 @@ def playlist_preview(payload: AddUrlRequest, request: Request) -> dict[str, Any]
         "source_url": preview.source_url,
         "title": preview.title,
         "channel": preview.channel,
+        "thumbnail_url": preview.thumbnail_url,
         "entries": preview.entries,
         "count": len(preview.entries),
     }

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -30,6 +30,7 @@ class Playlist(Base):
     source_url: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
     title: Mapped[Optional[str]] = mapped_column(String(512), nullable=True)
     channel: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    thumbnail_url: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     entry_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     pinned: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/app/db/repository.py
+++ b/app/db/repository.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from threading import Lock
 from typing import Iterator, Optional
 
-from sqlalchemy import Engine, Select, create_engine, delete, func, select, update
+from sqlalchemy import Engine, Select, create_engine, delete, func, select, text, update
 from sqlalchemy.orm import Session, sessionmaker
 
 from app.db.models import Base, PlayHistory, Playlist, PlaylistEntry, QueueItem, QueueStatus, Setting
@@ -43,6 +43,18 @@ class Repository:
 
     def init_db(self) -> None:
         Base.metadata.create_all(self.engine)
+        self._ensure_playlist_thumbnail_column()
+
+    def _ensure_playlist_thumbnail_column(self) -> None:
+        # Existing SQLite databases need an explicit ALTER TABLE when new
+        # nullable columns are introduced after the table was created.
+        if self.engine.url.get_backend_name() != "sqlite":
+            return
+        with self.engine.begin() as conn:
+            column_rows = conn.execute(text("PRAGMA table_info(playlists)")).mappings().all()
+            column_names = {row["name"] for row in column_rows}
+            if "thumbnail_url" not in column_names:
+                conn.execute(text("ALTER TABLE playlists ADD COLUMN thumbnail_url TEXT"))
 
     @contextmanager
     def session(self) -> Iterator[Session]:
@@ -126,7 +138,14 @@ class Repository:
             result = session.execute(delete(PlayHistory))
             return int(result.rowcount or 0)
 
-    def create_or_update_playlist(self, source_url: str, title: str | None, channel: str | None, entry_count: int) -> Playlist:
+    def create_or_update_playlist(
+        self,
+        source_url: str,
+        title: str | None,
+        channel: str | None,
+        entry_count: int,
+        thumbnail_url: str | None = None,
+    ) -> Playlist:
         with self.session() as session:
             playlist = session.scalar(select(Playlist).where(Playlist.source_url == source_url))
             if playlist is None:
@@ -134,12 +153,14 @@ class Repository:
                     source_url=source_url,
                     title=title,
                     channel=channel,
+                    thumbnail_url=thumbnail_url,
                     entry_count=entry_count,
                 )
                 session.add(playlist)
             else:
                 playlist.title = title
                 playlist.channel = channel
+                playlist.thumbnail_url = thumbnail_url
                 playlist.entry_count = entry_count
             session.flush()
             return playlist
@@ -241,6 +262,16 @@ class Repository:
         with self.session() as session:
             stmt = select(PlaylistEntry).where(PlaylistEntry.playlist_id == playlist_id).order_by(PlaylistEntry.position.asc())
             return list(session.scalars(stmt).all())
+
+    def get_first_playlist_entry(self, playlist_id: uuid.UUID) -> Optional[PlaylistEntry]:
+        with self.session() as session:
+            stmt = (
+                select(PlaylistEntry)
+                .where(PlaylistEntry.playlist_id == playlist_id)
+                .order_by(PlaylistEntry.position.asc(), PlaylistEntry.id.asc())
+                .limit(1)
+            )
+            return session.scalar(stmt)
 
     def queue_playlist(self, playlist_id: uuid.UUID, *, replace: bool = False) -> list[QueueItem]:
         entries = self.list_playlist_entries(playlist_id)

--- a/app/services/playlist_service.py
+++ b/app/services/playlist_service.py
@@ -51,6 +51,7 @@ class PlaylistService:
             title=preview.title,
             channel=preview.channel,
             entry_count=len(preview.entries),
+            thumbnail_url=preview.thumbnail_url,
         )
         entries = [
             NewPlaylistEntry(
@@ -72,11 +73,21 @@ class PlaylistService:
         }
 
     def _serialize_playlist(self, playlist) -> dict:
+        thumbnail_url = playlist.thumbnail_url
+        if not thumbnail_url:
+            first_entry = self.repository.get_first_playlist_entry(playlist.id)
+            if first_entry is not None:
+                thumbnail_url = first_entry.thumbnail_url
+                if not thumbnail_url:
+                    video_id = youtube_video_id_from_url(first_entry.source_url)
+                    if video_id:
+                        thumbnail_url = f"https://i.ytimg.com/vi/{video_id}/hqdefault.jpg"
         return {
             "id": playlist.id,
             "title": playlist.title or "Untitled playlist",
             "channel": playlist.channel,
             "source_url": playlist.source_url,
+            "thumbnail_url": thumbnail_url,
             "entry_count": playlist.entry_count,
             "pinned": playlist.pinned,
             "kind": "custom" if playlist.source_url.startswith("custom://") else "imported",

--- a/app/services/yt_dlp_service.py
+++ b/app/services/yt_dlp_service.py
@@ -41,6 +41,7 @@ class PlaylistPreview:
     title: str | None
     channel: str | None
     entries: list[dict[str, Any]]
+    thumbnail_url: str | None = None
 
 
 class YtDlpService:
@@ -157,6 +158,7 @@ class YtDlpService:
             title=data.get("title"),
             channel=data.get("uploader") or data.get("channel"),
             entries=entries,
+            thumbnail_url=data.get("thumbnail"),
         )
 
     def search_videos(self, query: str, limit: int = 10) -> list[dict[str, Any]]:

--- a/frontend/src/components/SidebarPlaylists.vue
+++ b/frontend/src/components/SidebarPlaylists.vue
@@ -29,6 +29,12 @@
           class="min-w-0 flex-1 justify-start"
           @click="selectPlaylist(router, playlist.id)"
         >
+          <img
+            v-if="playlistThumbnailSrc(playlist)"
+            :src="playlistThumbnailSrc(playlist)"
+            alt=""
+            class="h-10 w-10 shrink-0 rounded object-cover"
+          />
           <div class="min-w-0 text-left">
             <span class="block truncate text-sm font-medium">{{ playlist.title }}</span>
             <span class="block text-xs text-neutral-400">{{ playlist.kind }} · {{ playlist.entry_count }}</span>
@@ -196,5 +202,10 @@ function submitCreatePlaylist() {
   if (!title) return;
   createPlaylist(title);
   newTitle.value = "";
+}
+
+function playlistThumbnailSrc(playlist) {
+  if (!playlist) return "";
+  return playlist.thumbnail_url || "";
 }
 </script>

--- a/tests/test_api_extended.py
+++ b/tests/test_api_extended.py
@@ -25,7 +25,13 @@ class FakePlaylistService:
         return {"type": "video", "count": 1, "title": f"added:{url}", "item_ids": [1]}
 
     def preview_playlist(self, url: str):
-        return SimpleNamespace(source_url=url, title="preview", channel="chan", entries=[{"id": "1"}, {"id": "2"}])
+        return SimpleNamespace(
+            source_url=url,
+            title="preview",
+            channel="chan",
+            thumbnail_url="https://img.youtube.com/pl-preview.jpg",
+            entries=[{"id": "1"}, {"id": "2"}],
+        )
 
     def import_playlist(self, url: str) -> dict:
         return {"type": "playlist", "count": 2, "title": f"imported:{url}", "playlist_id": TEST_PLAYLIST_UUID, "item_ids": [2, 3]}
@@ -37,6 +43,7 @@ class FakePlaylistService:
                 "title": "Imported Playlist",
                 "channel": "chan",
                 "source_url": "https://www.youtube.com/playlist?list=pl",
+                "thumbnail_url": "https://img.youtube.com/pl.jpg",
                 "entry_count": 2,
                 "kind": "imported",
             }
@@ -50,6 +57,7 @@ class FakePlaylistService:
             "title": title,
             "channel": "Custom",
             "source_url": f"custom://{custom_id}",
+            "thumbnail_url": None,
             "entry_count": 0,
             "kind": "custom",
         }
@@ -254,6 +262,7 @@ def test_queue_playlist_and_history_endpoints(tmp_path):
         preview = client.post("/api/playlist/preview", json={"url": "https://www.youtube.com/playlist?list=pl"})
         assert preview.status_code == 200
         assert preview.json()["count"] == 2
+        assert preview.json()["thumbnail_url"] == "https://img.youtube.com/pl-preview.jpg"
 
         imported = client.post("/api/playlist/import", json={"url": "https://www.youtube.com/playlist?list=pl"})
         assert imported.status_code == 200
@@ -312,6 +321,7 @@ def test_playlist_library_endpoints(tmp_path):
         listed = playlists.json()
         assert len(listed) == 1
         assert listed[0]["id"] == str(TEST_PLAYLIST_UUID)
+        assert listed[0]["thumbnail_url"] == "https://img.youtube.com/pl.jpg"
 
         fetched = client.get(f"/api/playlists/{TEST_PLAYLIST_UUID}")
         assert fetched.status_code == 200

--- a/tests/test_playlist_service.py
+++ b/tests/test_playlist_service.py
@@ -9,6 +9,7 @@ from app.services.yt_dlp_service import PlaylistPreview, ResolvedTrack
 @dataclass
 class FakeYtDlp:
     playlist: bool = False
+    playlist_thumbnail_url: str | None = "https://img.youtube.com/pl.jpg"
 
     def is_playlist_url(self, url: str) -> bool:
         return self.playlist
@@ -47,6 +48,7 @@ class FakeYtDlp:
                     "thumbnail_url": None,
                 },
             ],
+            thumbnail_url=self.playlist_thumbnail_url,
         )
 
 
@@ -73,6 +75,18 @@ def test_import_playlist(tmp_path):
     assert result["count"] == 2
     queue = repo.list_queue()
     assert len(queue) == 2
+    playlists = service.list_playlists()
+    assert playlists[0]["thumbnail_url"] == "https://img.youtube.com/pl.jpg"
+
+
+def test_playlist_thumbnail_falls_back_to_first_entry(tmp_path):
+    repo = Repository(f"sqlite+pysqlite:///{tmp_path}/playlist_fallback.db")
+    repo.init_db()
+    service = PlaylistService(repo, FakeYtDlp(playlist=True, playlist_thumbnail_url=None))
+
+    service.import_playlist("https://youtube.com/playlist?list=x")
+    playlists = service.list_playlists()
+    assert playlists[0]["thumbnail_url"] == "https://i.ytimg.com/vi/1/hqdefault.jpg"
 
 
 def test_import_playlist_endpoint_behavior_is_library_only(tmp_path):


### PR DESCRIPTION
- Introduced `thumbnail_url` field in the `Playlist` model to store thumbnail images.
- Updated `create_or_update_playlist` method to handle thumbnail URLs.
- Enhanced `playlist_preview` function to include thumbnail information.
- Modified `PlaylistService` to serialize thumbnail URLs and provide fallback logic for missing thumbnails.
- Updated frontend components to display playlist thumbnails.
- Added tests to verify thumbnail handling and fallback behavior.