### PR TITLE
Remove HOST_IP references from configuration files and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ MYTUBE_PORT=8000
 MYTUBE_PUBLIC_BASE_URL=http://192.168.1.50:8000
 MYTUBE_FFMPEG_PATH=./bin/ffmpeg
 MYTUBE_YT_DLP_PATH=./bin/yt-dlp
-HOST_IP=192.168.1.50
 ```
 
 ### App Settings
@@ -53,19 +52,12 @@ HOST_IP=192.168.1.50
 | `MYTUBE_STREAM_STATS_LOG_SECONDS` | `15.0` | Interval for periodic stream-engine runtime stats logging. |
 | `MYTUBE_HISTORY_LIMIT` | `50` | Maximum number of playback history rows returned by `/history`. |
 
-### Special-Case Variable
-
-| Variable | Default | Purpose |
-| --- | --- | --- |
-| `HOST_IP` | unset | Fallback IP used when `MYTUBE_PUBLIC_BASE_URL` resolves to a non-routable or local-only host and the app needs a reachable stream URL for Sonos or other LAN clients. |
-
 ### Notes
 
-1. `MYTUBE_PUBLIC_BASE_URL` is the most important variable when clients outside the local browser need to reach the stream.
+1. `MYTUBE_PUBLIC_BASE_URL` is the variable used to build the public stream URL for browsers and Sonos; set it to your host or IP (e.g. `http://192.168.1.50:8000`) when clients outside the local browser need to reach the stream.
 2. If `MYTUBE_PUBLIC_BASE_URL` points at `localhost`, `0.0.0.0`, `host.docker.internal`, or another non-reachable host, the app tries to detect a LAN IP automatically.
-3. If automatic detection is not suitable, set `HOST_IP` to the machine IP you want embedded in the generated stream URL.
-4. `MYTUBE_FFMPEG_PATH` can be either a binary name on `PATH` or an explicit file path such as `./bin/ffmpeg`.
-5. `MYTUBE_YT_DLP_PATH` and `MYTUBE_FFMPEG_PATH` are the only variables used both by the app and by the install helper scripts.
+3. `MYTUBE_FFMPEG_PATH` can be either a binary name on `PATH` or an explicit file path such as `./bin/ffmpeg`.
+4. `MYTUBE_YT_DLP_PATH` and `MYTUBE_FFMPEG_PATH` are the only variables used both by the app and by the install helper scripts.
 
 ## Running Tests
 
@@ -79,7 +71,7 @@ HOST_IP=192.168.1.50
 
 If `ffmpeg` is missing, the app will try to auto-download a Linux binary from GitHub to `./bin/ffmpeg` at startup.
 
-If the app is running in Docker or otherwise resolves to a non-routable local address for Sonos clients, set `HOST_IP` to the machine IP you want the shared stream URL to use.
+If the app is running in Docker or otherwise resolves to a non-routable local address for Sonos clients, set `MYTUBE_PUBLIC_BASE_URL` to the full base URL (e.g. `http://192.168.1.50:8000`) you want the shared stream URL to use.
 
 ## Upgrading / database migrations
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import ipaddress
-import os
 import socket
 from functools import lru_cache
 from urllib.parse import urlsplit, urlunsplit
@@ -95,13 +94,10 @@ class Settings(BaseSettings):
             return configured
 
         detected_host = _detect_local_ip()
-        env_host = _extract_host(os.getenv("HOST_IP"))
         request_host = _extract_host(request_base_url)
 
         if detected_host and not _is_docker_address(detected_host):
             resolved_host = detected_host
-        elif env_host:
-            resolved_host = env_host
         elif _is_reachable_host(request_host):
             resolved_host = request_host
         else:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,6 @@ services:
     # Optional env (uncomment as needed):
     # environment:
     #   MYTUBE_PUBLIC_BASE_URL: "http://your-host-or-ip:8000"
-    #   HOST_IP: "192.168.1.100"
     #   MYTUBE_DB_URL: "sqlite+pysqlite:///./data/mytube.db"
     # volumes:
     #   - ./data:/app/data

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,12 +9,11 @@ def test_resolved_public_base_url_uses_detected_lan_ip(monkeypatch):
     assert settings.stream_url_for() == "http://192.168.1.44:8000/stream/live.mp3"
 
 
-def test_resolved_public_base_url_uses_host_ip_env_for_docker_ip(monkeypatch):
+def test_resolved_public_base_url_falls_back_to_configured_when_detected_is_docker(monkeypatch):
     monkeypatch.setattr(config_module, "_detect_local_ip", lambda: "172.17.0.3")
-    monkeypatch.setenv("HOST_IP", "192.168.1.55")
     settings = Settings(public_base_url="http://127.0.0.1:8000")
 
-    assert settings.stream_url_for() == "http://192.168.1.55:8000/stream/live.mp3"
+    assert settings.stream_url_for() == "http://127.0.0.1:8000/stream/live.mp3"
 
 
 def test_resolved_public_base_url_keeps_explicit_public_host(monkeypatch):


### PR DESCRIPTION
replacing them with clarifications on using MYTUBE_PUBLIC_BASE_URL for stream URL generation. Update tests to reflect these changes and ensure proper fallback behavior when detecting local IPs.