### PR TITLE
Add clear queue functionality to API and frontend

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -256,6 +256,17 @@ def remove_queue_item(item_id: int, request: Request) -> dict[str, bool]:
     return {"ok": ok}
 
 
+@api_router.delete("/queue")
+def clear_queue(request: Request) -> dict[str, bool]:
+    services = _services(request)
+    has_playing_item = any(item.status.value == "playing" for item in services["repo"].list_queue())
+    services["repo"].clear_queue()
+    if has_playing_item:
+        services["engine"].skip_current()
+    _publish_ui_snapshot(request)
+    return {"ok": True}
+
+
 @api_router.post("/queue/skip")
 def skip_current(request: Request) -> dict[str, bool]:
     _services(request)["engine"].skip_current()

--- a/app/db/repository.py
+++ b/app/db/repository.py
@@ -169,6 +169,16 @@ class Repository:
             result = session.execute(delete(PlayHistory))
             return int(result.rowcount or 0)
 
+    def clear_queue(self) -> int:
+        with self._queue_lock, self.session() as session:
+            removed = session.execute(
+                update(QueueItem).where(QueueItem.status == QueueStatus.queued).values(status=QueueStatus.removed)
+            )
+            skipped = session.execute(
+                update(QueueItem).where(QueueItem.status == QueueStatus.playing).values(status=QueueStatus.skipped)
+            )
+            return int((removed.rowcount or 0) + (skipped.rowcount or 0))
+
     def create_or_update_playlist(
         self,
         source_url: str,

--- a/frontend/src/components/QueuePanel.vue
+++ b/frontend/src/components/QueuePanel.vue
@@ -1,6 +1,19 @@
 <template>
   <section class="min-h-0 h-full overflow-hidden rounded-xl border border-neutral-700 p-3 flex flex-col surface-panel">
-    <h2 class="text-2xl font-bold">Queue</h2>
+    <div class="flex items-center justify-between gap-3">
+      <h2 class="text-2xl font-bold">Queue</h2>
+      <UButton
+        type="button"
+        color="error"
+        variant="soft"
+        size="xs"
+        :disabled="!filteredQueue.length"
+        class="shrink-0"
+        @click="clearQueue"
+      >
+        Clear Queue
+      </UButton>
+    </div>
     <ul class="mt-3 min-h-0 flex-1 space-y-2 overflow-auto pr-1">
       <li v-for="item in filteredQueue" :key="item.id">
         <Song
@@ -18,6 +31,6 @@ import { useLibraryState } from "../composables/useLibraryState";
 import { useQueueHistoryFilters } from "../composables/useUiState";
 import Song from "./Song.vue";
 
-const { queue, history, playlists } = useLibraryState();
+const { queue, history, playlists, clearQueue } = useLibraryState();
 const { filteredQueue } = useQueueHistoryFilters(queue, history);
 </script>

--- a/frontend/src/composables/useLibraryState.js
+++ b/frontend/src/composables/useLibraryState.js
@@ -172,6 +172,15 @@ export function useLibraryState() {
     }
   }
 
+  async function clearQueue() {
+    try {
+      await fetchJson("/api/queue", { method: "DELETE" });
+      notifySuccess("Queue cleared", "Queued tracks removed.");
+    } catch (error) {
+      notifyError("Could not clear queue", error);
+    }
+  }
+
   async function skipCurrent() {
     try {
       await fetchJson("/api/queue/skip", { method: "POST" });
@@ -253,6 +262,7 @@ export function useLibraryState() {
     setPlaylistPinned,
     deletePlaylist,
     clearHistory,
+    clearQueue,
     skipCurrent,
     previousTrack,
     togglePause,

--- a/tests/test_api_extended.py
+++ b/tests/test_api_extended.py
@@ -304,6 +304,41 @@ def test_queue_playlist_and_history_endpoints(tmp_path):
         assert isinstance(history_resp.json(), list)
 
 
+def test_clear_queue_endpoint_removes_all_visible_queue_items(tmp_path):
+    client, app = _build_test_client(tmp_path)
+    with client:
+        fake_engine = FakeEngine()
+        app.state.stream_engine = fake_engine
+        app.state.repository.enqueue_items(
+            [
+                NewQueueItem(
+                    source_url="https://www.youtube.com/watch?v=abc",
+                    normalized_url="https://www.youtube.com/watch?v=abc",
+                    source_type="video",
+                    title="Track A",
+                ),
+                NewQueueItem(
+                    source_url="https://www.youtube.com/watch?v=def",
+                    normalized_url="https://www.youtube.com/watch?v=def",
+                    source_type="video",
+                    title="Track B",
+                ),
+            ]
+        )
+        current = app.state.repository.dequeue_next()
+
+        assert current is not None
+
+        cleared = client.delete("/api/queue")
+        assert cleared.status_code == 200
+        assert cleared.json()["ok"] is True
+        assert fake_engine.skipped is True
+
+        queue_resp = client.get("/api/queue")
+        assert queue_resp.status_code == 200
+        assert queue_resp.json() == []
+
+
 def test_history_endpoint_includes_thumbnail_metadata(tmp_path):
     client, app = _build_test_client(tmp_path)
     with client:

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -109,6 +109,31 @@ def test_list_queue_repairs_multiple_playing_rows(tmp_path):
     assert refreshed_first.status == QueueStatus.skipped
 
 
+def test_clear_queue_marks_queued_removed_and_playing_skipped(tmp_path):
+    db_url = f"sqlite+pysqlite:///{tmp_path}/repo_clear_queue.db"
+    repo = Repository(db_url)
+    repo.init_db()
+
+    created = repo.enqueue_items(
+        [
+            NewQueueItem(source_url="u1", normalized_url="u1", source_type="video", title="a"),
+            NewQueueItem(source_url="u2", normalized_url="u2", source_type="video", title="b"),
+        ]
+    )
+    current = repo.dequeue_next()
+
+    assert current is not None
+    assert repo.clear_queue() == 2
+    assert repo.list_queue() == []
+
+    refreshed_first = repo.get_item(created[0].id)
+    refreshed_second = repo.get_item(created[1].id)
+    assert refreshed_first is not None
+    assert refreshed_second is not None
+    assert refreshed_first.status == QueueStatus.skipped
+    assert refreshed_second.status == QueueStatus.removed
+
+
 def test_history_preserves_thumbnail_url(tmp_path):
     db_url = f"sqlite+pysqlite:///{tmp_path}/repo_history.db"
     repo = Repository(db_url)


### PR DESCRIPTION
- Introduced a new DELETE endpoint to clear the queue, which removes all queued items and skips the currently playing item if applicable.
- Implemented the clearQueue method in the repository to update item statuses accordingly.
- Enhanced the QueuePanel component with a button to trigger the clear queue action.
- Added tests to verify the correct behavior of the clear queue functionality in both the API and repository layers.