### PR TITLE
Implement local audio playback and enhance player controls

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -96,12 +96,19 @@
       <PlayerBar v-else />
 
       <FullScreenPlayer v-if="isMobile" />
+
+      <audio
+        ref="audioEl"
+        class="hidden"
+        :src="playbackState.stream_url"
+        preload="none"
+      />
     </div>
   </UApp>
 </template>
 
 <script setup>
-import { onMounted } from "vue";
+import { onMounted, provide, ref } from "vue";
 import { useRoute } from "vue-router";
 
 import FullScreenPlayer from "./components/FullScreenPlayer.vue";
@@ -113,9 +120,10 @@ import SidebarPlaylists from "./components/SidebarPlaylists.vue";
 import SonosPanel from "./components/SonosPanel.vue";
 import TopBar from "./components/TopBar.vue";
 import { useBreakpoint } from "./composables/useBreakpoint";
+import { useLocalPlayback } from "./composables/useLocalPlayback";
 import { initializeLibraryState } from "./composables/useLibraryState";
 import { initializeNotifications } from "./composables/useNotifications";
-import { initializePlaybackState } from "./composables/usePlaybackState";
+import { initializePlaybackState, usePlaybackState } from "./composables/usePlaybackState";
 import { initializeSonosState } from "./composables/useSonosState";
 import {
   MOBILE_VIEW_HOME,
@@ -129,6 +137,20 @@ import { initializeTheme } from "./composables/useTheme";
 
 const route = useRoute();
 const { isMobile } = useBreakpoint();
+const { playbackState } = usePlaybackState();
+const audioEl = ref(null);
+const {
+  startLocalPlayback,
+  stopLocalPlayback,
+  isLocalPlaybackActive,
+} = useLocalPlayback(audioEl);
+
+provide("localPlayback", {
+  startLocalPlayback,
+  stopLocalPlayback,
+  isLocalPlaybackActive,
+});
+
 const {
   sidebarView,
   activeQueueTab,

--- a/frontend/src/components/FullScreenPlayer.vue
+++ b/frontend/src/components/FullScreenPlayer.vue
@@ -166,17 +166,53 @@
             @click="cycleRepeatMode"
           />
         </div>
+        <div class="fullscreen-player-local-controls mt-3 flex flex-wrap items-center justify-center gap-2">
+          <a
+            class="text-xs font-medium text-emerald-400 hover:text-emerald-300"
+            :href="playbackState.stream_url"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Stream
+          </a>
+          <UButton
+            type="button"
+            color="primary"
+            variant="soft"
+            size="xs"
+            :disabled="!playbackState.stream_url || isLocalPlaybackActive"
+            @click="startLocalPlayback"
+          >
+            Play Local
+          </UButton>
+          <UButton
+            type="button"
+            color="neutral"
+            variant="outline"
+            size="xs"
+            :disabled="!isLocalPlaybackActive"
+            @click="stopLocalPlayback"
+          >
+            Stop Local
+          </UButton>
+        </div>
       </div>
     </div>
   </Teleport>
 </template>
 
 <script setup>
-import { computed, ref, watch } from "vue";
+import { computed, inject, ref, watch } from "vue";
 import { formatDuration } from "../composables/useDuration";
 import { useLibraryState } from "../composables/useLibraryState";
 import { usePlaybackState } from "../composables/usePlaybackState";
 import { useUiState } from "../composables/useUiState";
+
+const {
+  startLocalPlayback,
+  stopLocalPlayback,
+  isLocalPlaybackActive,
+} = inject("localPlayback");
 
 const progressTrackEl = ref(null);
 const { playbackState } = usePlaybackState();

--- a/frontend/src/components/PlayerBar.vue
+++ b/frontend/src/components/PlayerBar.vue
@@ -172,27 +172,28 @@
       </div>
     </div>
 
-    <audio ref="audioEl" class="hidden" :src="playbackState.stream_url" preload="none"></audio>
   </footer>
 </template>
 
 <script setup>
-import { computed, onUnmounted, ref, watch } from "vue";
+import { computed, inject, ref } from "vue";
 import { formatDuration } from "../composables/useDuration";
 import { useBreakpoint } from "../composables/useBreakpoint";
 import { useLibraryState } from "../composables/useLibraryState";
 import { usePlaybackState } from "../composables/usePlaybackState";
 import { SIDEBAR_QUEUE_VIEW, SIDEBAR_SONOS_VIEW, fullScreenPlayerOpen, useUiState } from "../composables/useUiState";
 
-const audioEl = ref(null);
+const {
+  startLocalPlayback,
+  stopLocalPlayback,
+  isLocalPlaybackActive,
+} = inject("localPlayback");
+
 const progressTrackEl = ref(null);
-const wantsLocalPlayback = ref(false);
 const { isMobile } = useBreakpoint();
 const { playbackState } = usePlaybackState();
 const { sidebarView } = useUiState();
 const { skipCurrent, previousTrack, togglePause, setRepeatMode, setShuffleEnabled, seekToPercent } = useLibraryState();
-
-const isLocalPlaybackActive = computed(() => wantsLocalPlayback.value && Boolean(playbackState.value.stream_url));
 const playPauseIcon = computed(() =>
   playbackState.value.mode === "playing" && !playbackState.value.paused ? "i-lucide-pause" : "i-lucide-play"
 );
@@ -222,50 +223,4 @@ function onProgressClick(event) {
   const percent = Math.max(0, Math.min(100, raw));
   seekToPercent(percent);
 }
-
-async function startLocalPlayback() {
-  if (!audioEl.value || !playbackState.value.stream_url) return;
-  wantsLocalPlayback.value = true;
-  audioEl.value.load();
-  try {
-    await audioEl.value.play();
-  } catch {
-    wantsLocalPlayback.value = false;
-  }
-}
-
-function stopLocalPlayback() {
-  wantsLocalPlayback.value = false;
-  if (!audioEl.value) return;
-  audioEl.value.pause();
-  try {
-    audioEl.value.currentTime = 0;
-  } catch {
-    // Some live streams do not support seeking back to the start.
-  }
-}
-
-watch(
-  () => playbackState.value.stream_url,
-  async (streamUrl) => {
-    if (!audioEl.value) return;
-    if (!streamUrl) {
-      stopLocalPlayback();
-      return;
-    }
-    if (!wantsLocalPlayback.value) return;
-    audioEl.value.load();
-    try {
-      await audioEl.value.play();
-    } catch {
-      wantsLocalPlayback.value = false;
-    }
-  },
-  { immediate: true }
-);
-
-onUnmounted(() => {
-  if (!audioEl.value) return;
-  audioEl.value.pause();
-});
 </script>

--- a/frontend/src/composables/useLocalPlayback.js
+++ b/frontend/src/composables/useLocalPlayback.js
@@ -1,0 +1,67 @@
+import { computed, onUnmounted, ref, watch } from "vue";
+
+import { usePlaybackState } from "./usePlaybackState";
+
+/**
+ * Shared local playback over a single audio element. Call from the component that owns the element (e.g. App.vue).
+ * @param {import('vue').Ref<HTMLAudioElement | null>} audioRef
+ */
+export function useLocalPlayback(audioRef) {
+  const { playbackState } = usePlaybackState();
+  const wantsLocalPlayback = ref(false);
+
+  const isLocalPlaybackActive = computed(() => wantsLocalPlayback.value);
+
+  async function startLocalPlayback() {
+    if (!audioRef.value || !playbackState.value.stream_url) return;
+
+    wantsLocalPlayback.value = true;
+    audioRef.value.src = playbackState.value.stream_url;
+
+    try {
+      await audioRef.value.play();
+    } catch {
+      stopLocalPlayback();
+    }
+  }
+
+  function stopLocalPlayback() {
+    if (!audioRef.value) return;
+
+    wantsLocalPlayback.value = false;
+
+    audioRef.value.pause();
+    audioRef.value.removeAttribute("src");
+    audioRef.value.load();
+  }
+
+  watch(
+    () => playbackState.value.stream_url,
+    async (newUrl) => {
+      if (!newUrl) {
+        stopLocalPlayback();
+        return;
+      }
+
+      if (!wantsLocalPlayback.value || !audioRef.value) return;
+
+      audioRef.value.src = newUrl;
+
+      try {
+        await audioRef.value.play();
+      } catch {
+        stopLocalPlayback();
+      }
+    }
+  );
+
+  onUnmounted(() => {
+    stopLocalPlayback();
+  });
+
+  return {
+    startLocalPlayback,
+    stopLocalPlayback,
+    isLocalPlaybackActive,
+  };
+}


### PR DESCRIPTION
- Added local playback capabilities in App.vue, integrating audio playback state management.
- Enhanced FullScreenPlayer.vue with buttons to start and stop local playback, improving user interaction.
- Refactored PlayerBar.vue to remove direct audio element handling, utilizing injected local playback methods for better state management.
- Introduced a new composable, useLocalPlayback, to manage local audio playback logic.