### PR TITLE
Add Deno support and update documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ dist/
 data/airwave.db
 data/mytube.db
 
+bin/deno
 bin/ffmpeg
 bin/yt-dlp
 node_modules/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Use this file as the default working guide for code agents in this repo. Keep ch
 
 - Backend: Python 3.10+, FastAPI, SQLAlchemy, Jinja2, `soco`
 - Frontend: Vue 3, Vue Router, Vite, `@nuxt/ui`
-- Runtime tools: `yt-dlp`, `ffmpeg`
+- Runtime tools: `yt-dlp`, `deno`, `ffmpeg`
 - Storage: SQLite by default via `AIRWAVE_DB_URL`
 
 ## Repository Map
@@ -55,6 +55,7 @@ python -m pip install --upgrade pip setuptools wheel
 python -m pip install ".[dev]"
 npm install
 ./scripts/setup_yt_dlp.sh
+./scripts/setup_deno.sh
 ```
 
 Optional:

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,19 @@ RUN mkdir -p /build/bin \
     && curl -fsSL "https://github.com/yt-dlp/yt-dlp/releases/latest/download/${ASSET}" -o /build/bin/yt-dlp \
     && chmod +x /build/bin/yt-dlp
 
+# Download and install Deno (JS runtime for yt-dlp EJS)
+RUN ARCH=$(uname -m) \
+    && case "$ARCH" in \
+        x86_64|amd64) DENO_ASSET="deno-x86_64-unknown-linux-gnu.zip" ;; \
+        aarch64|arm64) DENO_ASSET="deno-aarch64-unknown-linux-gnu.zip" ;; \
+        *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL "https://github.com/denoland/deno/releases/latest/download/${DENO_ASSET}" -o /tmp/deno.zip \
+    && unzip -q /tmp/deno.zip -d /tmp/deno-extract \
+    && mv /tmp/deno-extract/deno /build/bin/deno \
+    && chmod +x /build/bin/deno \
+    && rm -rf /tmp/deno.zip /tmp/deno-extract
+
 # Download and install ffmpeg
 RUN ARCH=$(uname -m) \
     && case "$ARCH" in \
@@ -89,6 +102,7 @@ COPY --chown=airwave:airwave --from=builder /build/app/static/dist ./app/static/
 
 # Copy binaries from builder
 COPY --chown=airwave:airwave --from=builder /build/bin/yt-dlp ./bin/yt-dlp
+COPY --chown=airwave:airwave --from=builder /build/bin/deno ./bin/deno
 COPY --chown=airwave:airwave --from=builder /build/bin/ffmpeg ./bin/ffmpeg
 
 # Set environment variables

--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ A WSL-friendly FastAPI application that exposes one shared live MP3 stream for a
    - `npm run build`
 4. Install `yt-dlp` binary:
    - `./scripts/setup_yt_dlp.sh`
-5. (Optional) install `ffmpeg` manually:
+5. Install `deno` (JS runtime for yt-dlp YouTube support):
+   - `./scripts/setup_deno.sh`
+6. (Optional) install `ffmpeg` manually:
    - `./scripts/setup_ffmpeg.sh`
-6. Start the app:
+7. Start the app:
    - `./scripts/run_dev.sh`
 
 Open `http://127.0.0.1:8000`.

--- a/scripts/setup_deno.sh
+++ b/scripts/setup_deno.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN_DIR="$ROOT_DIR/bin"
+TARGET_PATH="$BIN_DIR/deno"
+mkdir -p "$BIN_DIR"
+
+ARCH="$(uname -m)"
+OS="$(uname -s)"
+if [[ "$OS" == "Linux" ]]; then
+  case "$ARCH" in
+    x86_64|amd64) DENO_ASSET="deno-x86_64-unknown-linux-gnu.zip" ;;
+    aarch64|arm64) DENO_ASSET="deno-aarch64-unknown-linux-gnu.zip" ;;
+    *)
+      echo "Unsupported architecture: $ARCH" >&2
+      exit 1
+      ;;
+  esac
+elif [[ "$OS" == "Darwin" ]]; then
+  case "$ARCH" in
+    x86_64|amd64) DENO_ASSET="deno-x86_64-apple-darwin.zip" ;;
+    aarch64|arm64) DENO_ASSET="deno-aarch64-apple-darwin.zip" ;;
+    *)
+      echo "Unsupported architecture: $ARCH" >&2
+      exit 1
+      ;;
+  esac
+else
+  echo "Unsupported OS: $OS" >&2
+  exit 1
+fi
+
+DOWNLOAD_URL="https://github.com/denoland/deno/releases/latest/download/${DENO_ASSET}"
+echo "Downloading Deno from ${DOWNLOAD_URL}"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+curl -fsSL "$DOWNLOAD_URL" -o "$TMP_DIR/deno.zip"
+unzip -q "$TMP_DIR/deno.zip" -d "$TMP_DIR"
+mv "$TMP_DIR/deno" "$TARGET_PATH"
+chmod +x "$TARGET_PATH"
+"$TARGET_PATH" --version
+echo "Installed Deno to $TARGET_PATH"


### PR DESCRIPTION
- Added Deno installation to the Dockerfile for enhanced runtime capabilities.
- Updated AGENTS.md to include Deno as a runtime tool.
- Modified README.md to include instructions for installing Deno.
- Added Deno to .gitignore to prevent tracking of its binary.