### PR TITLE
Add reorder functionality for playlist entries

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -523,6 +523,15 @@ def delete_playlist_entry(entry_id: int, request: Request) -> Response:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
+@api_router.post("/playlists/entries/{entry_id}/reorder")
+def reorder_playlist_entry(entry_id: int, payload: ReorderRequest, request: Request) -> dict[str, bool]:
+    try:
+        _services(request)["playlist"].reorder_playlist_entry(entry_id, payload.new_position)
+        return {"ok": True}
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
 @api_router.websocket("/ws/events")
 async def websocket_events(websocket: WebSocket) -> None:
     broker = websocket.app.state.ui_events

--- a/app/db/repository.py
+++ b/app/db/repository.py
@@ -364,6 +364,31 @@ class Repository:
                 playlist.entry_count -= 1
             return True
 
+    def reorder_playlist_entry(self, entry_id: int, new_position: int) -> bool:
+        with self.session() as session:
+            entry = session.get(PlaylistEntry, entry_id)
+            if entry is None:
+                return False
+            playlist_id = entry.playlist_id
+            entries = list(
+                session.scalars(
+                    select(PlaylistEntry)
+                    .where(PlaylistEntry.playlist_id == playlist_id)
+                    .order_by(PlaylistEntry.position.asc())
+                ).all()
+            )
+            if not entries:
+                return False
+            idx = next((i for i, e in enumerate(entries) if e.id == entry_id), None)
+            if idx is None:
+                return False
+            item = entries.pop(idx)
+            bounded_target = max(0, min(new_position, len(entries)))
+            entries.insert(bounded_target, item)
+            for pos, e in enumerate(entries, start=1):
+                e.position = pos
+            return True
+
     def has_queued_items(self) -> bool:
         with self.session() as session:
             count = session.scalar(select(func.count(QueueItem.id)).where(QueueItem.status == QueueStatus.queued))

--- a/app/services/playlist_service.py
+++ b/app/services/playlist_service.py
@@ -167,3 +167,7 @@ class PlaylistService:
     def remove_playlist_entry(self, entry_id: int) -> None:
         if not self.repository.delete_playlist_entry(entry_id):
             raise ValueError("Playlist entry not found")
+
+    def reorder_playlist_entry(self, entry_id: int, new_position: int) -> None:
+        if not self.repository.reorder_playlist_entry(entry_id, new_position):
+            raise ValueError("Playlist entry not found")

--- a/frontend/src/composables/useLibraryState.js
+++ b/frontend/src/composables/useLibraryState.js
@@ -194,6 +194,18 @@ export function useLibraryState() {
     }
   }
 
+  async function reorderPlaylistEntry(entryId, newPosition) {
+    try {
+      await fetchJson(`/api/playlists/entries/${entryId}/reorder`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ new_position: newPosition }),
+      });
+    } catch (error) {
+      notifyError("Could not reorder playlist", error);
+    }
+  }
+
   async function skipCurrent() {
     try {
       await fetchJson("/api/queue/skip", { method: "POST" });
@@ -277,6 +289,7 @@ export function useLibraryState() {
     clearHistory,
     clearQueue,
     reorderQueueItem,
+    reorderPlaylistEntry,
     skipCurrent,
     previousTrack,
     togglePause,

--- a/frontend/src/pages/playlist/[id].vue
+++ b/frontend/src/pages/playlist/[id].vue
@@ -12,7 +12,18 @@
 
       <div v-if="!entries.length" class="mt-4 text-sm text-muted">This playlist has no entries yet.</div>
 
-      <ul v-else class="mt-4 space-y-2">
+      <VueDraggable
+        v-else
+        v-model="entries"
+        tag="ul"
+        class="mt-4 space-y-2"
+        :animation="150"
+        :delay="200"
+        :delay-on-touch-only="true"
+        ghost-class="queue-drag-ghost"
+        chosen-class="queue-drag-chosen"
+        @end="onReorderEnd"
+      >
         <li v-for="entry in entries" :key="entry.id">
           <Song
             :item="entry"
@@ -23,7 +34,7 @@
             @deleted="loadPlaylist()"
           />
         </li>
-      </ul>
+      </VueDraggable>
     </template>
   </section>
 </template>
@@ -32,11 +43,13 @@
 import { ref, watch } from "vue";
 import { useRoute } from "vue-router";
 
+import { VueDraggable } from "vue-draggable-plus";
+
 import Song from "../../components/Song.vue";
 import { fetchJson } from "../../composables/useApi";
 import { useLibraryState } from "../../composables/useLibraryState";
 
-const { playlists } = useLibraryState();
+const { playlists, reorderPlaylistEntry } = useLibraryState();
 
 const route = useRoute();
 const playlist = ref({});
@@ -98,6 +111,14 @@ async function loadPlaylist() {
       loading.value = false;
     }
   }
+}
+
+function onReorderEnd(evt) {
+  const { oldIndex, newIndex } = evt;
+  if (oldIndex === newIndex) return;
+  const entry = entries.value[newIndex];
+  if (!entry?.id) return;
+  reorderPlaylistEntry(entry.id, newIndex);
 }
 
 watch(


### PR DESCRIPTION
- Introduced a new API endpoint to reorder playlist entries via a POST request.
- Implemented the reorder logic in the repository to update entry positions within a playlist.
- Enhanced the PlaylistService to handle reordering requests and raise errors for invalid entries.
- Updated the frontend to support drag-and-drop reordering of playlist entries using vue-draggable-plus, integrating the new API call for reordering.