### PR TITLE
Enhance YouTube URL handling in YtDlpService and TopBar component

### DIFF
--- a/app/services/yt_dlp_service.py
+++ b/app/services/yt_dlp_service.py
@@ -63,8 +63,18 @@ class YtDlpService:
                 return f"https://www.youtube.com/playlist?list={playlist_id}"
         return url
 
+    def is_start_radio_url(self, url: str) -> bool:
+        """True for YouTube watch URLs with start_radio=1 (mix/radio)."""
+        parsed = urlparse(url)
+        if "youtube.com" not in parsed.netloc or "watch" not in parsed.path:
+            return False
+        query = parse_qs(parsed.query)
+        return query.get("start_radio", [None])[0] == "1"
+
     def is_playlist_url(self, url: str) -> bool:
-        """True only for playlist page URLs (playlist?list=...). Watch URLs are always single-video."""
+        """True for playlist page URLs (playlist?list=...) or watch URLs with start_radio=1."""
+        if self.is_start_radio_url(url):
+            return True
         parsed = urlparse(url)
         query = parse_qs(parsed.query)
         return "/playlist" in parsed.path and "list" in query
@@ -129,12 +139,12 @@ class YtDlpService:
         )
 
     def preview_playlist(self, url: str) -> PlaylistPreview:
-        normalized = self.normalize_url(url)
+        url_for_ytdlp = url if self.is_start_radio_url(url) else self.normalize_url(url)
         data = self._run_json(
             "--flat-playlist",
             "--skip-download",
             "-J",
-            normalized,
+            url_for_ytdlp,
         )
         entries: list[dict[str, Any]] = []
         for entry in data.get("entries", []):
@@ -154,7 +164,7 @@ class YtDlpService:
                 }
             )
         return PlaylistPreview(
-            source_url=normalized,
+            source_url=url_for_ytdlp,
             title=data.get("title"),
             channel=data.get("uploader") or data.get("channel"),
             entries=entries,

--- a/frontend/src/components/TopBar.vue
+++ b/frontend/src/components/TopBar.vue
@@ -153,6 +153,28 @@ function hasPlaylistId(rawUrl) {
   return rawUrl.includes("list=");
 }
 
+function isStartRadioUrl(rawUrl) {
+  const parsed = parseInputUrl(rawUrl);
+  if (!parsed) return false;
+  return parsed.searchParams.get("start_radio") === "1";
+}
+
+function getVideoOnlyUrl(rawUrl) {
+  const parsed = parseInputUrl(rawUrl);
+  if (!parsed) return rawUrl;
+  const videoId = parsed.searchParams.get("v");
+  if (!videoId) return rawUrl;
+  const host = parsed.hostname.toLowerCase();
+  const knownYoutubeHost = host === "youtube.com"
+    || host === "www.youtube.com"
+    || host === "m.youtube.com"
+    || host === "music.youtube.com"
+    || host === "youtu.be"
+    || host === "www.youtu.be";
+  if (!knownYoutubeHost) return rawUrl;
+  return `https://www.youtube.com/watch?v=${encodeURIComponent(videoId)}`;
+}
+
 function isCanonicalPlaylistPath(rawUrl) {
   const parsed = parseInputUrl(rawUrl);
   if (!parsed) return false;
@@ -182,6 +204,7 @@ const actionContext = computed(() => {
   const rawUrl = urlInput.value.trim();
   if (!rawUrl) return "single";
   if (isCanonicalPlaylistPath(rawUrl)) return "canonical-playlist";
+  if (hasPlaylistId(rawUrl) && isStartRadioUrl(rawUrl)) return "start-radio";
   if (hasPlaylistId(rawUrl)) return "playlist-capable";
   return "single";
 });
@@ -194,8 +217,8 @@ const defaultActionId = computed(() => {
     }
     return ACTION_IDS.ADD_URL;
   }
-
-  return actionContext.value === "canonical-playlist" ? ACTION_IDS.PLAY_PLAYLIST : ACTION_IDS.PLAY_URL;
+  if (actionContext.value === "canonical-playlist") return ACTION_IDS.PLAY_PLAYLIST;
+  return ACTION_IDS.PLAY_URL;
 });
 
 const availableActions = computed(() => {
@@ -203,7 +226,15 @@ const availableActions = computed(() => {
     { id: ACTION_IDS.PLAY_URL, label: "Play" },
     { id: ACTION_IDS.ADD_URL, label: "Queue" },
   ];
-  if (actionContext.value === "playlist-capable" || actionContext.value === "canonical-playlist") {
+  if (actionContext.value === "start-radio") {
+    base = [
+      { id: ACTION_IDS.ADD_URL, label: "Queue" },
+      { id: ACTION_IDS.PLAY_URL, label: "Play" },
+      { id: ACTION_IDS.PLAY_PLAYLIST, label: "Play Playlist" },
+      { id: ACTION_IDS.QUEUE_PLAYLIST, label: "Queue Playlist" },
+      { id: ACTION_IDS.IMPORT_PLAYLIST, label: "Import playlist" },
+    ];
+  } else if (actionContext.value === "playlist-capable" || actionContext.value === "canonical-playlist") {
     base = [
       { id: ACTION_IDS.PLAY_URL, label: "Play" },
       { id: ACTION_IDS.PLAY_PLAYLIST, label: "Play Playlist" },
@@ -242,17 +273,20 @@ function runAction(actionId, closeAfter = false) {
   const rawUrl = consumeInputUrl();
   if (!rawUrl) return;
 
-  const canonicalPlaylistUrl = getCanonicalPlaylistUrl(rawUrl);
+  const isStartRadio = isStartRadioUrl(rawUrl);
+  const urlForSingle = isStartRadio ? getVideoOnlyUrl(rawUrl) : rawUrl;
+  const urlForPlaylist = isStartRadio ? rawUrl : getCanonicalPlaylistUrl(rawUrl);
+
   if (actionId === ACTION_IDS.PLAY_PLAYLIST) {
-    playUrl(canonicalPlaylistUrl);
+    playUrl(urlForPlaylist);
   } else if (actionId === ACTION_IDS.QUEUE_PLAYLIST) {
-    addUrl(canonicalPlaylistUrl);
+    addUrl(urlForPlaylist);
   } else if (actionId === ACTION_IDS.IMPORT_PLAYLIST) {
-    importPlaylistUrl(canonicalPlaylistUrl);
+    importPlaylistUrl(urlForPlaylist);
   } else if (actionId === ACTION_IDS.ADD_URL) {
-    addUrl(rawUrl);
+    addUrl(urlForSingle);
   } else {
-    playUrl(rawUrl);
+    playUrl(urlForSingle);
   }
 
   if (closeAfter) {

--- a/tests/test_yt_dlp_service.py
+++ b/tests/test_yt_dlp_service.py
@@ -20,6 +20,20 @@ def test_is_playlist_url_watch_single_video(service):
 
 
 def test_is_playlist_url_watch_with_list_param_treated_as_single_video(service):
-    """watch?v=...&list=... should queue/play only the video, not the full playlist."""
+    """watch?v=...&list=... without start_radio should queue/play only the video."""
     url = "https://www.youtube.com/watch?v=Hjw86NcG8Bo&list=PLMmqTuUsDkRIZ1C1T2AsVz5XIxtVDfSOe"
     assert service.is_playlist_url(url) is False
+
+
+def test_is_start_radio_url(service):
+    assert service.is_start_radio_url("https://www.youtube.com/watch?v=u6wOyMUs74I&list=RDu6wOyMUs74I&start_radio=1") is True
+    assert service.is_start_radio_url("https://www.youtube.com/watch?v=HMUDVMiITOU&list=RDMMHMUDVMiITOU&start_radio=1") is True
+    assert service.is_start_radio_url("https://www.youtube.com/watch?v=Hjw86NcG8Bo&list=PLxxx") is False
+    assert service.is_start_radio_url("https://www.youtube.com/watch?v=Hjw86NcG8Bo") is False
+    assert service.is_start_radio_url("https://www.youtube.com/playlist?list=PLxxx") is False
+
+
+def test_is_playlist_url_start_radio(service):
+    """watch?v=...&list=...&start_radio=1 should be treated as playlist for import/queue."""
+    url = "https://www.youtube.com/watch?v=u6wOyMUs74I&list=RDu6wOyMUs74I&start_radio=1"
+    assert service.is_playlist_url(url) is True


### PR DESCRIPTION
- Added a method to identify YouTube watch URLs with start_radio=1 in YtDlpService.
- Updated is_playlist_url method to treat URLs with start_radio=1 as playlists.
- Modified the TopBar component to recognize start_radio URLs and adjust action handling accordingly.
- Implemented utility functions for URL normalization and video-only URL extraction.
- Added tests for start_radio URL detection and its integration with playlist handling.