### PR TITLE
Add playlist sorting

### DIFF
--- a/app/db/repository.py
+++ b/app/db/repository.py
@@ -254,6 +254,8 @@ class Repository:
                 playlist.thumbnail_url = thumbnail_url
                 playlist.entry_count = entry_count
             session.flush()
+            # Ensure server-default timestamps are populated before detaching.
+            session.refresh(playlist)
             return playlist
 
     def create_custom_playlist(self, title: str) -> Playlist:
@@ -267,12 +269,42 @@ class Repository:
             session.add(playlist)
             session.flush()
             playlist.source_url = f"custom://{str(playlist.id)}"
+            # Ensure server-default timestamps are populated before detaching.
+            session.refresh(playlist)
             return playlist
 
     def list_playlists(self) -> list[Playlist]:
         with self.session() as session:
             stmt = select(Playlist).order_by(Playlist.pinned.desc(), Playlist.updated_at.desc())
             return list(session.scalars(stmt).all())
+
+    def playlist_last_played_at_by_id(self) -> dict[uuid.UUID, datetime]:
+        """Return last playback activity per playlist_id.
+
+        Uses the latest QueueItem.updated_at for items that reached a playback-related
+        status (playing/completed/skipped/failed). Queued/removed items are ignored.
+        """
+        playback_statuses = [
+            QueueStatus.playing,
+            QueueStatus.completed,
+            QueueStatus.skipped,
+            QueueStatus.failed,
+        ]
+        with self.session() as session:
+            rows = session.execute(
+                select(QueueItem.playlist_id, func.max(QueueItem.updated_at))
+                .where(
+                    QueueItem.playlist_id.is_not(None),
+                    QueueItem.status.in_(playback_statuses),
+                )
+                .group_by(QueueItem.playlist_id)
+            ).all()
+            result: dict[uuid.UUID, datetime] = {}
+            for playlist_id, last_played_at in rows:
+                if playlist_id is None or last_played_at is None:
+                    continue
+                result[playlist_id] = last_played_at
+            return result
 
     def update_playlist(
         self,
@@ -293,6 +325,8 @@ class Repository:
             if pinned is not None:
                 playlist.pinned = pinned
             session.flush()
+            # Ensure onupdate timestamps are reflected before detaching.
+            session.refresh(playlist)
             return playlist
 
     def get_playlist(self, playlist_id: uuid.UUID) -> Optional[Playlist]:

--- a/app/services/playlist_service.py
+++ b/app/services/playlist_service.py
@@ -315,6 +315,9 @@ class PlaylistService:
             "entry_count": playlist.entry_count,
             "pinned": playlist.pinned,
             "kind": kind,
+            "created_at": playlist.created_at.isoformat() if getattr(playlist, "created_at", None) else None,
+            "updated_at": playlist.updated_at.isoformat() if getattr(playlist, "updated_at", None) else None,
+            "last_played_at": None,
         }
 
     @staticmethod
@@ -374,6 +377,13 @@ class PlaylistService:
     def list_playlists(self) -> list[dict]:
         playlists = self.repository.list_playlists()
         serialized = [self._serialize_playlist(p) for p in playlists]
+        last_played_by_id = self.repository.playlist_last_played_at_by_id()
+        for playlist in serialized:
+            pid = playlist.get("id")
+            if pid is None:
+                continue
+            last_played_at = last_played_by_id.get(pid)
+            playlist["last_played_at"] = last_played_at.isoformat() if last_played_at is not None else None
         known_sources = {
             (playlist.get("source_url") or "").strip()
             for playlist in serialized
@@ -401,6 +411,9 @@ class PlaylistService:
                     "kind": "remote_youtube",
                     "provider": remote.provider,
                     "provider_item_id": remote.provider_item_id,
+                    "created_at": None,
+                    "updated_at": None,
+                    "last_played_at": None,
                 }
             )
         return self._apply_sidebar_order(serialized)

--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -34,6 +34,7 @@ declare module 'vue' {
     UButton: typeof import('./../node_modules/@nuxt/ui/dist/runtime/components/Button.vue')['default']
     UDropdownMenu: typeof import('./../node_modules/@nuxt/ui/dist/runtime/components/DropdownMenu.vue')['default']
     UIcon: typeof import('./../node_modules/@nuxt/ui/dist/runtime/vue/components/Icon.vue')['default']
+    UInput: typeof import('./../node_modules/@nuxt/ui/dist/runtime/components/Input.vue')['default']
     UModal: typeof import('./../node_modules/@nuxt/ui/dist/runtime/components/Modal.vue')['default']
     UScrollArea: typeof import('./../node_modules/@nuxt/ui/dist/runtime/components/ScrollArea.vue')['default']
     USlider: typeof import('./../node_modules/@nuxt/ui/dist/runtime/components/Slider.vue')['default']

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -80,7 +80,7 @@
               <UTabs
                 v-model="activeQueueTab"
                 :items="queueSidebarTabs"
-                class="w-full min-h-0 flex-1 flex flex-col overflow-hidden"
+                class="surface-panel rounded-t-xl w-full min-h-0 flex-1 flex flex-col overflow-hidden"
                 :ui="{ content: 'min-h-0 flex-1 flex flex-col overflow-hidden' }"
                 :unmount-on-hide="false"
               >

--- a/frontend/src/components/PlaylistItem.vue
+++ b/frontend/src/components/PlaylistItem.vue
@@ -27,7 +27,7 @@
         <span class="block text-xs text-muted">{{ label }} · {{ playlist.entry_count }}</span>
       </div>
     </div>
-    <div class="shrink-0 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100" @click.stop>
+    <div class="shrink-0 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100 md:any-pointer-coarse:opacity-100" @click.stop>
       <UDropdownMenu
         :items="dropdownItems"
         :ui="{ separator: 'hidden' }"

--- a/frontend/src/components/PlaylistSelectorFilter.vue
+++ b/frontend/src/components/PlaylistSelectorFilter.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col gap-2 px-2 py-1.5">
+  <div class="flex flex-col gap-2 px-2 py-1.5 w-full">
     <div class="flex items-center gap-2">
       <UIcon name="i-bi-search" class="size-4 shrink-0 text-muted" />
       <input

--- a/frontend/src/components/SidebarPlaylists.vue
+++ b/frontend/src/components/SidebarPlaylists.vue
@@ -309,7 +309,7 @@ const sortOptions = computed(() => {
 });
 
 const canDragReorder = computed(() => {
-  return sortMode.value === "custom" && !playlistSearchTerm.value.trim();
+  return sortMode.value === "custom" && !playlistSearchTerm.value.trim() && playlistSearchTerm.value.length === 0;
 });
 
 function onPlaylistClick(playlist) {

--- a/frontend/src/components/SidebarPlaylists.vue
+++ b/frontend/src/components/SidebarPlaylists.vue
@@ -117,7 +117,7 @@
           />
         </VueDraggable>
 
-        <ul v-else :class="pinnedPlaylists.length ? 'mt-2 space-y-2' : 'space-y-2'">
+        <ul v-else :class="filteredUnpinnedPlaylists.length ? 'mt-2 space-y-2' : 'space-y-2'">
           <PlaylistItem
             v-for="playlist in filteredUnpinnedPlaylists"
             :key="playlist.id"

--- a/frontend/src/components/SidebarPlaylists.vue
+++ b/frontend/src/components/SidebarPlaylists.vue
@@ -335,14 +335,15 @@ function playlistLabel(playlist) {
 }
 
 watch(
-  playlists,
-  (items) => {
+  [playlists, sortMode],
+  ([items]) => {
     const next = Array.isArray(items) ? items : [];
-    if(sortMode.value === "custom") {
+    if (sortMode.value === "custom") {
       pinnedPlaylists.value = next.filter((playlist) => !!playlist?.pinned);
       unpinnedPlaylists.value = next.filter((playlist) => !playlist?.pinned);
     } else {
       unpinnedPlaylists.value = next;
+      pinnedPlaylists.value = [];
     }
   },
   { immediate: true },

--- a/frontend/src/components/SidebarPlaylists.vue
+++ b/frontend/src/components/SidebarPlaylists.vue
@@ -1,79 +1,167 @@
 <template>
   <aside class="min-h-0 h-full overflow-hidden rounded-xl border border-neutral-700 p-3 flex flex-col surface-panel">
-    <h2 class="text-2xl font-bold">Playlists</h2>
-    <form class="mt-3 flex gap-2" @submit.prevent="submitCreatePlaylist">
-      <input
-        v-model="newTitle"
-        type="text"
-        placeholder="New playlist"
-        required
-        class="h-10 min-w-0 flex-1 rounded-md border px-3 text-sm surface-input"
-      />
-      <UButton type="submit" color="primary" variant="solid" size="md">
-        Create
+    <div class="flex items-center justify-between gap-2 pr-1">
+      <h2 class="text-2xl font-bold">Playlists</h2>
+      <UButton
+        class="justify-center cursor-pointer"
+        color="neutral"
+        variant="soft"
+        size="md"
+        icon="i-bi-plus-lg"
+        @click="openCreateModal"
+      >
+        New playlist
       </UButton>
-    </form>
+    </div>
+    
+    <div class="grid grid-cols-2 gap-2 mt-3 pr-1">
+      <!-- Search for playlists -->
+       <div class="flex-1">
+      <UInput
+          v-model="playlistSearchTerm"
+          type="text"
+          placeholder="Search for playlists"
+        >
+          
+          <template v-if="playlistSearchTerm?.length" #trailing>
+            <UButton
+              color="neutral"
+              variant="link"
+              size="sm"
+              class="cursor-pointer"
+              icon="i-lucide-circle-x"
+              aria-label="Clear input"
+              @click="playlistSearchTerm = ''"
+            />
+          </template>
+        </UInput>
+      </div>
+      <div class="flex justify-end shrink-0 ">
+        <UDropdownMenu :items="sortOptions">
+          <UButton color="neutral" variant="ghost">
+            {{ sortOrder.label }}
+            <UIcon name="i-bi-list-task" class="size-4" />
+          </UButton>
+        </UDropdownMenu>
+      </div>
+    </div>
 
     <div
       class="mt-3 min-h-0 flex-1 overflow-auto pr-1"
       @click="(e) => e.target === e.currentTarget && selectPlaylist(router, null)"
     >
-      <VueDraggable
-        v-if="pinnedPlaylists.length"
-        v-model="pinnedPlaylists"
-        tag="ul"
-        class="space-y-2"
-        :animation="150"
-        :delay="200"
-        :delay-on-touch-only="true"
-        ghost-class="queue-drag-ghost"
-        chosen-class="queue-drag-chosen"
-        @end="(evt) => onReorderEnd(evt, true)"
-      >
-        <PlaylistItem
-          v-for="playlist in pinnedPlaylists"
-          :key="playlist.id"
-          :playlist="playlist"
-          :active-playlist-id="activePlaylistId"
-          :is-remote-playlist="isRemotePlaylist"
-          :thumbnail-src="playlistThumbnailSrc(playlist)"
-          :label="playlistLabel(playlist)"
-          @click="onPlaylistClick"
-          @clear-active-playlist="clearActivePlaylist"
-        />
-      </VueDraggable>
+      <template v-if="filteredPinnedPlaylists.length">
+        <VueDraggable
+          v-if="canDragReorder"
+          v-model="pinnedPlaylists"
+          tag="ul"
+          class="space-y-2"
+          :animation="150"
+          :delay="200"
+          :delay-on-touch-only="true"
+          ghost-class="queue-drag-ghost"
+          chosen-class="queue-drag-chosen"
+          @end="(evt) => onReorderEnd(evt, true)"
+        >
+          <PlaylistItem
+            v-for="playlist in pinnedPlaylists"
+            :key="playlist.id"
+            :playlist="playlist"
+            :active-playlist-id="activePlaylistId"
+            :is-remote-playlist="isRemotePlaylist"
+            :thumbnail-src="playlistThumbnailSrc(playlist)"
+            :label="playlistLabel(playlist)"
+            @click="onPlaylistClick"
+            @clear-active-playlist="clearActivePlaylist"
+          />
+        </VueDraggable>
 
-      <VueDraggable
-        v-if="unpinnedPlaylists.length"
-        v-model="unpinnedPlaylists"
-        tag="ul"
-        :class="pinnedPlaylists.length ? 'mt-2 space-y-2' : 'space-y-2'"
-        :animation="150"
-        :delay="200"
-        :delay-on-touch-only="true"
-        ghost-class="queue-drag-ghost"
-        chosen-class="queue-drag-chosen"
-        @end="(evt) => onReorderEnd(evt, false)"
-      >
-        <PlaylistItem
-          v-for="playlist in unpinnedPlaylists"
-          :key="playlist.id"
-          :playlist="playlist"
-          :active-playlist-id="activePlaylistId"
-          :is-remote-playlist="isRemotePlaylist"
-          :thumbnail-src="playlistThumbnailSrc(playlist)"
-          :label="playlistLabel(playlist)"
-          @click="onPlaylistClick"
-          @clear-active-playlist="clearActivePlaylist"
-        />
-      </VueDraggable>
+        <ul v-else class="space-y-2">
+          <PlaylistItem
+            v-for="playlist in filteredPinnedPlaylists"
+            :key="playlist.id"
+            :playlist="playlist"
+            :active-playlist-id="activePlaylistId"
+            :is-remote-playlist="isRemotePlaylist"
+            :thumbnail-src="playlistThumbnailSrc(playlist)"
+            :label="playlistLabel(playlist)"
+            @click="onPlaylistClick"
+            @clear-active-playlist="clearActivePlaylist"
+          />
+        </ul>
+      </template>
+
+      <template v-if="filteredUnpinnedPlaylists.length">
+        <VueDraggable
+          v-if="canDragReorder"
+          v-model="unpinnedPlaylists"
+          tag="ul"
+          :class="pinnedPlaylists.length ? 'mt-2 space-y-2' : 'space-y-2'"
+          :animation="150"
+          :delay="200"
+          :delay-on-touch-only="true"
+          ghost-class="queue-drag-ghost"
+          chosen-class="queue-drag-chosen"
+          @end="(evt) => onReorderEnd(evt, false)"
+        >
+          <PlaylistItem
+            v-for="playlist in unpinnedPlaylists"
+            :key="playlist.id"
+            :playlist="playlist"
+            :active-playlist-id="activePlaylistId"
+            :is-remote-playlist="isRemotePlaylist"
+            :thumbnail-src="playlistThumbnailSrc(playlist)"
+            :label="playlistLabel(playlist)"
+            @click="onPlaylistClick"
+            @clear-active-playlist="clearActivePlaylist"
+          />
+        </VueDraggable>
+
+        <ul v-else :class="pinnedPlaylists.length ? 'mt-2 space-y-2' : 'space-y-2'">
+          <PlaylistItem
+            v-for="playlist in filteredUnpinnedPlaylists"
+            :key="playlist.id"
+            :playlist="playlist"
+            :active-playlist-id="activePlaylistId"
+            :is-remote-playlist="isRemotePlaylist"
+            :thumbnail-src="playlistThumbnailSrc(playlist)"
+            :label="playlistLabel(playlist)"
+            @click="onPlaylistClick"
+            @clear-active-playlist="clearActivePlaylist"
+          />
+        </ul>
+      </template>
     </div>
 
+    <UModal v-model:open="createModalOpen" :ui="{ width: 'max-w-sm' }">
+      <template #content>
+        <form class="p-4" @submit.prevent="submitCreatePlaylist">
+          <h3 class="text-lg font-semibold">New playlist</h3>
+          <input
+            ref="createTitleInputRef"
+            v-model="newTitle"
+            type="text"
+            class="mt-3 w-full rounded-md border px-3 py-2 text-sm surface-input"
+            placeholder="Playlist name"
+            required
+            @keydown.enter.prevent="submitCreatePlaylist"
+          />
+          <div class="mt-4 flex justify-end gap-2">
+            <UButton type="button" color="neutral" variant="ghost" @click="closeCreateModal">
+              Cancel
+            </UButton>
+            <UButton type="submit" color="primary" variant="solid">
+              Create
+            </UButton>
+          </div>
+        </form>
+      </template>
+    </UModal>
   </aside>
 </template>
 
 <script setup>
-import { ref, watch } from "vue";
+import { computed, nextTick, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import { VueDraggable } from "vue-draggable-plus";
 import PlaylistItem from "./PlaylistItem.vue";
@@ -81,7 +169,12 @@ import PlaylistItem from "./PlaylistItem.vue";
 import { useLibraryState } from "../composables/useLibraryState";
 import { useUiState } from "../composables/useUiState";
 
+const SIDEBAR_SORT_MODE_STORAGE_KEY = "airwave:ui:sidebar-playlists:sort-mode";
+const DEFAULT_SORT_MODE = "custom";
+
 const newTitle = ref("");
+const createModalOpen = ref(false);
+const createTitleInputRef = ref(null);
 const router = useRouter();
 const {
   playlists,
@@ -93,9 +186,131 @@ const { activePlaylistId, selectPlaylist } = useUiState();
 const pinnedPlaylists = ref([]);
 const unpinnedPlaylists = ref([]);
 
+const playlistSearchTerm = ref("");
+const sortMode = ref(DEFAULT_SORT_MODE);
+
+function loadSortMode() {
+  try {
+    const raw = localStorage.getItem(SIDEBAR_SORT_MODE_STORAGE_KEY);
+    if (!raw) return DEFAULT_SORT_MODE;
+    return raw;
+  } catch {
+    return DEFAULT_SORT_MODE;
+  }
+}
+
+function saveSortMode(nextMode) {
+  try {
+    localStorage.setItem(SIDEBAR_SORT_MODE_STORAGE_KEY, nextMode);
+  } catch {
+    // ignore
+  }
+}
+
+sortMode.value = loadSortMode();
+
+const SORT_OPTIONS = [
+  { label: "Custom", value: "custom", icon: "i-bi-list-check" },
+  { label: "Recently Played", value: "recent", icon: "i-bi-clock-fill" },
+  { label: "Recently Added", value: "recently-added", icon: "i-bi-plus-lg" },
+  { label: "Alphabetical", value: "alphabetical", icon: "i-bi-sort-alpha-down" },
+];
+
+const sortOrder = computed(() => {
+  return SORT_OPTIONS.find((o) => o.value === sortMode.value) || SORT_OPTIONS[0];
+});
+
+watch(
+  sortMode,
+  (val) => {
+    saveSortMode(val);
+  },
+  { immediate: false },
+);
+
 function isRemotePlaylist(playlist) {
   return playlist?.kind === "remote_youtube";
 }
+
+function stableIndexMap(items) {
+  const map = new Map();
+  items.forEach((item, idx) => {
+    map.set(item?.id, idx);
+  });
+  return map;
+}
+
+function toEpochMillis(isoString) {
+  if (!isoString) return null;
+  const t = Date.parse(isoString);
+  if (Number.isNaN(t)) return null;
+  return t;
+}
+
+function sortWithinGroup(items, mode, stableOrder) {
+  if (mode === "custom") return items.slice();
+  const next = items.slice();
+  next.sort((a, b) => {
+    if (mode === "alphabetical") {
+      const at = (a?.title || "").toLowerCase();
+      const bt = (b?.title || "").toLowerCase();
+      if (at < bt) return -1;
+      if (at > bt) return 1;
+    } else if (mode === "recent") {
+      const av = toEpochMillis(a?.last_played_at);
+      const bv = toEpochMillis(b?.last_played_at);
+      if (av != null || bv != null) {
+        if (av == null) return 1;
+        if (bv == null) return -1;
+        if (av !== bv) return bv - av;
+      }
+    } else if (mode === "recently-added") {
+      const av = toEpochMillis(a?.created_at);
+      const bv = toEpochMillis(b?.created_at);
+      if (av != null || bv != null) {
+        if (av == null) return 1;
+        if (bv == null) return -1;
+        if (av !== bv) return bv - av;
+      }
+    }
+
+    const ai = stableOrder.get(a?.id);
+    const bi = stableOrder.get(b?.id);
+    if (ai == null && bi == null) return 0;
+    if (ai == null) return 1;
+    if (bi == null) return -1;
+    return ai - bi;
+  });
+  return next;
+}
+
+const filteredPinnedPlaylists = computed(() => {
+  const term = playlistSearchTerm.value.toLowerCase();
+  const base = pinnedPlaylists.value.filter((playlist) => playlist.title.toLowerCase().includes(term));
+  const stable = stableIndexMap(pinnedPlaylists.value);
+  return sortWithinGroup(base, sortMode.value, stable);
+});
+
+const filteredUnpinnedPlaylists = computed(() => {
+  const term = playlistSearchTerm.value.toLowerCase();
+  const base = unpinnedPlaylists.value.filter((playlist) => playlist.title.toLowerCase().includes(term));
+  const stable = stableIndexMap(unpinnedPlaylists.value);
+  return sortWithinGroup(base, sortMode.value, stable);
+});
+
+const sortOptions = computed(() => {
+  return SORT_OPTIONS.map((opt) => ({
+    label: opt.label,
+    icon: opt.icon,
+    onSelect: () => {
+      sortMode.value = opt.value;
+    },
+  }));
+});
+
+const canDragReorder = computed(() => {
+  return sortMode.value === "custom" && !playlistSearchTerm.value.trim();
+});
 
 function onPlaylistClick(playlist) {
   if (isRemotePlaylist(playlist)) {
@@ -123,20 +338,36 @@ watch(
   playlists,
   (items) => {
     const next = Array.isArray(items) ? items : [];
-    pinnedPlaylists.value = next.filter((playlist) => !!playlist?.pinned);
-    unpinnedPlaylists.value = next.filter((playlist) => !playlist?.pinned);
+    if(sortMode.value === "custom") {
+      pinnedPlaylists.value = next.filter((playlist) => !!playlist?.pinned);
+      unpinnedPlaylists.value = next.filter((playlist) => !playlist?.pinned);
+    } else {
+      unpinnedPlaylists.value = next;
+    }
   },
   { immediate: true },
 );
+
+function openCreateModal() {
+  newTitle.value = "";
+  createModalOpen.value = true;
+  nextTick(() => createTitleInputRef.value?.focus?.());
+}
+
+function closeCreateModal() {
+  createModalOpen.value = false;
+  newTitle.value = "";
+}
 
 function submitCreatePlaylist() {
   const title = newTitle.value.trim();
   if (!title) return;
   createPlaylist(title);
-  newTitle.value = "";
+  closeCreateModal();
 }
 
 async function onReorderEnd(evt, pinned) {
+  if (!canDragReorder.value) return;
   const { oldIndex, newIndex } = evt;
   if (oldIndex === newIndex) return;
   const list = pinned ? pinnedPlaylists.value : unpinnedPlaylists.value;

--- a/frontend/src/components/Song.vue
+++ b/frontend/src/components/Song.vue
@@ -13,7 +13,7 @@
         referrerpolicy="no-referrer"
       />
       <div
-        class="absolute inset-0 flex cursor-pointer items-center justify-center bg-black/40 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100"
+        class="absolute inset-0 flex cursor-pointer items-center justify-center bg-black/40 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100 md:any-pointer-coarse:opacity-100"
         aria-hidden
       >
         <UIcon name="i-bi-play-fill" class="size-8 text-white drop-shadow-md" />
@@ -38,7 +38,7 @@
     </div>
     <div
       v-if="dropdownItems.length > 0"
-      class="shrink-0 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100"
+      class="shrink-0 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100 md:any-pointer-coarse:opacity-100"
       @click.stop
     >
       <UDropdownMenu :items="dropdownItems" :ui="{ separator: 'hidden' }" @update:open="(open) => !open && resetSearch()">

--- a/frontend/src/components/TopBar.vue
+++ b/frontend/src/components/TopBar.vue
@@ -18,12 +18,25 @@
           class="self-start sm:self-auto"
           @click="router.push('/')"
         />
-        <input
+        <UInput
           v-model="unifiedInput"
           type="text"
           placeholder="Search or paste URL (YouTube, SoundCloud, Mixcloud, Spotify playlist, or direct MP3/audio link)…"
-          class="h-10 w-full min-w-0 flex-1 rounded-md border px-3 text-sm sm:min-w-[400px] sm:max-w-[800px] surface-input"
-        />
+          class="h-10 w-full min-w-0 flex-1 text-sm sm:min-w-[400px] sm:max-w-[800px]"
+          >
+          
+          <template v-if="unifiedInput?.length" #trailing>
+            <UButton
+              color="neutral"
+              variant="link"
+              size="sm"
+              class="cursor-pointer"
+              icon="i-lucide-circle-x"
+              aria-label="Clear input"
+              @click="unifiedInput = ''"
+            />
+          </template>
+        </UInput>
         <template v-if="isUrlInput">
           <div class="flex w-full sm:w-auto">
             <UButton

--- a/frontend/src/css/style.css
+++ b/frontend/src/css/style.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@config "../../tailwind.config.cjs";
 @import "@nuxt/ui";
 @import "./themes/night.css";
 @import "./themes/dark.css";

--- a/frontend/src/pages/playlist/[id].vue
+++ b/frontend/src/pages/playlist/[id].vue
@@ -77,12 +77,12 @@
         </template>
         <!-- Search for songs in playlist -->
         <UInput
-          v-model="playlistSearchTerm"
+          v-model="songSearchTerm"
           type="text"
           placeholder="Search for songs in playlist"
         >
           
-          <template v-if="playlistSearchTerm?.length" #trailing>
+          <template v-if="songSearchTerm?.length" #trailing>
             <UButton
               color="neutral"
               variant="link"
@@ -90,7 +90,7 @@
               class="cursor-pointer"
               icon="i-lucide-circle-x"
               aria-label="Clear input"
-              @click="playlistSearchTerm = ''"
+              @click="songSearchTerm = ''"
             />
           </template>
         </UInput>
@@ -243,7 +243,7 @@ const totalDurationSeconds = computed(() =>
 const formattedTotalDuration = computed(() => formatTotalDuration(totalDurationSeconds.value));
 
 const filteredEntries = computed(() => {
-  return entries.value.filter((e) => e.title.toLowerCase().includes(playlistSearchTerm.value.toLowerCase()));
+  return entries.value.filter((e) => e.title.toLowerCase().includes(songSearchTerm.value.toLowerCase()));
 });
 
 const dropdownItems = computed(() => {

--- a/frontend/src/pages/playlist/[id].vue
+++ b/frontend/src/pages/playlist/[id].vue
@@ -232,6 +232,7 @@ const firstTrackThumbnail = computed(() => {
     return `https://i.ytimg.com/vi/${first.provider_item_id}/hqdefault.jpg`;
   }
 });
+const songSearchTerm = ref("");
 
 const songCount = computed(() => entries.value.length || playlist.value?.entry_count || 0);
 const isRemotePlaylistView = computed(() => playlist.value?.kind === "remote_youtube");

--- a/frontend/src/pages/playlist/[id].vue
+++ b/frontend/src/pages/playlist/[id].vue
@@ -31,7 +31,7 @@
       </div>
 
       <!-- Action row -->
-      <div class="mt-4 flex items-center gap-2">
+      <div class="mt-4 mb-4 flex items-center gap-2">
         <template v-if="isRemotePlaylistView">
           <UButton
             type="button"
@@ -75,6 +75,25 @@
           />
         </UDropdownMenu>
         </template>
+        <!-- Search for songs in playlist -->
+        <UInput
+          v-model="playlistSearchTerm"
+          type="text"
+          placeholder="Search for songs in playlist"
+        >
+          
+          <template v-if="playlistSearchTerm?.length" #trailing>
+            <UButton
+              color="neutral"
+              variant="link"
+              size="sm"
+              class="cursor-pointer"
+              icon="i-lucide-circle-x"
+              aria-label="Clear input"
+              @click="playlistSearchTerm = ''"
+            />
+          </template>
+        </UInput>
       </div>
 
       <div v-if="isRemotePlaylistView" class="mt-6 text-sm text-muted">
@@ -98,7 +117,7 @@
           chosen-class="queue-drag-chosen"
           @end="onReorderEnd"
         >
-          <li v-for="entry in entries" :key="entry.id">
+          <li v-for="entry in filteredEntries" :key="entry.id">
             <Song
               :item="entry"
               mode="search"
@@ -205,7 +224,6 @@ const editDescription = ref("");
 const playlistToEdit = ref(null);
 const deleteModalOpen = ref(false);
 const playlistToDelete = ref(null);
-
 const firstTrackThumbnail = computed(() => {
   if(playlist.value?.thumbnail_url) return playlist.value.thumbnail_url;
   const first = entries.value[0];
@@ -223,6 +241,10 @@ const totalDurationSeconds = computed(() =>
 );
 
 const formattedTotalDuration = computed(() => formatTotalDuration(totalDurationSeconds.value));
+
+const filteredEntries = computed(() => {
+  return entries.value.filter((e) => e.title.toLowerCase().includes(playlistSearchTerm.value.toLowerCase()));
+});
 
 const dropdownItems = computed(() => {
   const pl = playlist.value;

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -1,0 +1,6 @@
+/** @type {import("tailwindcss").Config} */
+module.exports = {
+  future: {
+    hoverOnlyWhenSupported: true
+  }
+};

--- a/tests/test_api_extended.py
+++ b/tests/test_api_extended.py
@@ -60,6 +60,9 @@ class FakePlaylistService:
                 "thumbnail_url": "https://img.youtube.com/pl.jpg",
                 "entry_count": 2,
                 "kind": "imported",
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": "2026-01-02T00:00:00+00:00",
+                "last_played_at": None,
             }
         ]
 
@@ -562,12 +565,18 @@ def test_playlist_library_endpoints(tmp_path):
         assert listed[0]["thumbnail_url"] == "https://img.youtube.com/pl.jpg"
         assert "provider" not in listed[0]
         assert "provider_item_id" not in listed[0]
+        assert "created_at" in listed[0]
+        assert "updated_at" in listed[0]
+        assert "last_played_at" in listed[0]
 
         fetched = client.get(f"/api/playlists/{TEST_PLAYLIST_UUID}")
         assert fetched.status_code == 200
         assert fetched.json()["title"] == "Imported Playlist"
         assert "provider" not in fetched.json()
         assert "provider_item_id" not in fetched.json()
+        assert "created_at" in fetched.json()
+        assert "updated_at" in fetched.json()
+        assert "last_played_at" in fetched.json()
 
         missing_playlist = client.get("/api/playlists/00000000-0000-0000-0000-000000000001")
         assert missing_playlist.status_code == 404

--- a/tests/test_playlist_service.py
+++ b/tests/test_playlist_service.py
@@ -151,6 +151,9 @@ def test_update_playlist_rename_and_pin(tmp_path):
     assert created["pinned"] is False
     assert "provider" not in created
     assert "provider_item_id" not in created
+    assert isinstance(created.get("created_at"), str)
+    assert isinstance(created.get("updated_at"), str)
+    assert created.get("last_played_at") is None
 
     updated = service.update_playlist(pid, title="Renamed")
     assert updated["title"] == "Renamed"
@@ -230,6 +233,66 @@ def test_list_playlists_merges_remote_youtube_playlists(tmp_path):
     assert playlists[0]["kind"] == "remote_youtube"
     assert playlists[0]["source_url"] == "https://www.youtube.com/playlist?list=PLremote1"
     assert playlists[0]["provider_item_id"] == "PLremote1"
+    assert playlists[0].get("created_at") is None
+    assert playlists[0].get("updated_at") is None
+    assert playlists[0].get("last_played_at") is None
+
+
+def test_list_playlists_includes_last_played_at_from_playback_statuses_only(tmp_path):
+    repo = Repository(f"sqlite+pysqlite:///{tmp_path}/last_played.db")
+    repo.init_db()
+    service = PlaylistService(repo, FakeYtDlp())
+
+    created = service.create_custom_playlist("P1")
+    pid = created["id"]
+
+    # Queued-only items should NOT count as "recently played"
+    repo.enqueue_items(
+        [
+            NewQueueItem(
+                source_url="u1",
+                normalized_url="u1",
+                source_type="video",
+                title="seed",
+                playlist_id=pid,
+            )
+        ]
+    )
+    listed = service.list_playlists()
+    match = next(p for p in listed if p["id"] == pid)
+    assert match["last_played_at"] is None
+
+    # Playback statuses should count; latest updated_at wins.
+    playing = repo.dequeue_next()
+    assert playing is not None
+    after_playing = service.list_playlists()
+    match_after_playing = next(p for p in after_playing if p["id"] == pid)
+    assert isinstance(match_after_playing["last_played_at"], str)
+
+    repo.mark_playback_finished(playing.id, QueueStatus.completed)
+    after_completed = service.list_playlists()
+    match_after_completed = next(p for p in after_completed if p["id"] == pid)
+    assert isinstance(match_after_completed["last_played_at"], str)
+
+    # Removed items should not override the last played timestamp.
+    repo.enqueue_items(
+        [
+            NewQueueItem(
+                source_url="u2",
+                normalized_url="u2",
+                source_type="video",
+                title="seed2",
+                playlist_id=pid,
+            )
+        ]
+    )
+    queued = repo.list_queue()
+    queued_only = next((item for item in queued if item.status == QueueStatus.queued and item.playlist_id == pid), None)
+    assert queued_only is not None
+    repo.remove_item(queued_only.id)  # becomes removed (ignored)
+    after_removed = service.list_playlists()
+    match_after_removed = next(p for p in after_removed if p["id"] == pid)
+    assert match_after_removed["last_played_at"] == match_after_completed["last_played_at"]
 
 
 def test_list_playlists_ignores_remote_lookup_failures(tmp_path):


### PR DESCRIPTION
- Added a new method to the Repository class to retrieve the last played timestamp for each playlist based on playback activity.
- Updated the PlaylistService to include the last played timestamp in the serialized playlist data.
- Enhanced the SidebarPlaylists component to display the last played timestamp alongside other playlist details.
- Ensured server-default timestamps are populated before detaching playlists in the Repository methods.
- Updated tests to verify the inclusion of created_at, updated_at, and last_played_at fields in playlist responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Playlist search, filtering, and persistent sorting (alphabetical, recently played, recently added, custom)
  * Song search within playlists with clear buttons; new-playlist modal and drag-to-reorder (custom sort only)
* **Style**
  * Improved touch responsiveness and unified input styling (UInput); minor layout/class tweaks for better visibility
* **Chores**
  * Playlists now surface created_at, updated_at, and last_played_at; last_played_at reflects playback-completed statuses only
* **Tests**
  * Updated tests to cover timestamp and last_played_at behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->