### PR TITLE
Update PlayerBar and fullscreen-player components to improve like/unlike button functionality

### DIFF
--- a/frontend/src/components/PlayerBar.vue
+++ b/frontend/src/components/PlayerBar.vue
@@ -24,9 +24,9 @@
           <p class="flex items-center gap-1.5 truncate text-sm font-semibold">
             <span class="min-w-0 truncate">{{ playbackState.now_playing_title || "No active track" }}</span>
             <UButton
+              v-if="playbackState.now_playing_id"
               type="button"
-              :disabled="!playbackState.now_playing_id"
-              :color="playbackState.now_playing_is_liked ? 'error' : 'neutral'"
+              :color="playbackState.now_playing_is_liked ? 'success' : 'neutral'"
               variant="ghost"
               size="xs"
               class="shrink-0 p-0.5"
@@ -77,9 +77,9 @@
           <p class="flex items-center gap-1.5 truncate text-base font-semibold">
             <span class="min-w-0 truncate">{{ playbackState.now_playing_title || "No active track" }}</span>
             <UButton
+              v-if="playbackState.now_playing_id"
               type="button"
-              :disabled="!playbackState.now_playing_id"
-              :color="playbackState.now_playing_is_liked ? 'error' : 'neutral'"
+              :color="playbackState.now_playing_is_liked ? 'success' : 'neutral'"
               variant="ghost"
               size="xs"
               class="shrink-0 p-0.5"

--- a/frontend/src/pages/fullscreen-player.vue
+++ b/frontend/src/pages/fullscreen-player.vue
@@ -22,9 +22,9 @@
           <p class="flex items-center justify-center gap-2 truncate text-lg font-bold">
             <span class="min-w-0 truncate">{{ playbackState.now_playing_title || "No active track" }}</span>
             <UButton
+              v-if="playbackState.now_playing_id"
               type="button"
-              :disabled="!playbackState.now_playing_id"
-              :color="playbackState.now_playing_is_liked ? 'error' : 'neutral'"
+              :color="playbackState.now_playing_is_liked ? 'success' : 'neutral'"
               variant="ghost"
               size="xs"
               class="shrink-0 p-0.5"
@@ -80,9 +80,9 @@
               <h2 class="flex items-center gap-2 text-xl font-bold leading-tight">
                 <span class="min-w-0 truncate">{{ playbackState.now_playing_title || "No active track" }}</span>
                 <UButton
+                  v-if="playbackState.now_playing_id"
                   type="button"
-                  :disabled="!playbackState.now_playing_id"
-                  :color="playbackState.now_playing_is_liked ? 'error' : 'neutral'"
+                  :color="playbackState.now_playing_is_liked ? 'success' : 'neutral'"
                   variant="ghost"
                   size="xs"
                   class="shrink-0 p-0.5"


### PR DESCRIPTION
- Added conditional rendering for the like/unlike button based on the presence of the currently playing track.
- Updated button color logic to reflect the liked state, changing from 'error' to 'success' for liked tracks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the like button behavior—it now only appears when a song is actively playing, eliminating unnecessary visual clutter
  * Updated the like button's color indicator to provide clearer visual feedback for liked songs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->