### PR TITLE
Enhance setup scripts for better error handling and OS support

### DIFF
--- a/scripts/run_dev.sh
+++ b/scripts/run_dev.sh
@@ -12,7 +12,11 @@ fi
 if [[ ! -f "app/static/dist/app.js" ]]; then
   if command -v npm >/dev/null 2>&1; then
     echo "Building frontend assets..."
-    npm run build
+    if ! npm run build; then
+      echo "Frontend build failed; attempting npm install and retrying..." >&2
+      npm install
+      npm run build
+    fi
   else
     echo "Frontend bundle missing and npm is not available." >&2
     exit 1

--- a/scripts/setup_ffmpeg.sh
+++ b/scripts/setup_ffmpeg.sh
@@ -23,14 +23,37 @@ if [[ "$OS" == "Linux" ]]; then
       ;;
   esac
 elif [[ "$OS" == "Darwin" ]]; then
-  case "$ARCH" in
-    x86_64|amd64) ASSET_URL="https://github.com/yt-dlp/FFmpeg-Builds/releases/latest/download/ffmpeg-master-latest-macos64-gpl.zip" ;;
-    aarch64|arm64) ASSET_URL="https://github.com/yt-dlp/FFmpeg-Builds/releases/latest/download/ffmpeg-master-latest-macosarm64-gpl.zip" ;;
-    *)
-      echo "Unsupported architecture: $ARCH" >&2
+  # `yt-dlp/FFmpeg-Builds` no longer publishes macOS artifacts.
+  # On macOS we prefer an existing `ffmpeg` on PATH, otherwise Homebrew.
+  if command -v ffmpeg >/dev/null 2>&1; then
+    echo "Using ffmpeg from PATH: $(command -v ffmpeg)"
+    cp "$(command -v ffmpeg)" "$TARGET_PATH"
+    chmod +x "$TARGET_PATH"
+    "$TARGET_PATH" -version | head -n 1
+    echo "Installed ffmpeg to $TARGET_PATH"
+    exit 0
+  fi
+
+  if command -v brew >/dev/null 2>&1; then
+    echo "Installing ffmpeg via Homebrew..."
+    # Homebrew can occasionally return non-zero while still installing the formula
+    # (e.g. post-install warnings). If ffmpeg ends up on PATH, proceed.
+    if ! brew install ffmpeg; then
+      echo "Homebrew reported an error; checking whether ffmpeg is available anyway..." >&2
+    fi
+    if ! command -v ffmpeg >/dev/null 2>&1; then
+      echo "ffmpeg is still not available on PATH after Homebrew install." >&2
       exit 1
-      ;;
-  esac
+    fi
+    cp "$(command -v ffmpeg)" "$TARGET_PATH"
+    chmod +x "$TARGET_PATH"
+    "$TARGET_PATH" -version | head -n 1
+    echo "Installed ffmpeg to $TARGET_PATH"
+    exit 0
+  fi
+
+  echo "ffmpeg not found. Install it (e.g. via Homebrew) or set AIRWAVE_FFMPEG_PATH to an existing ffmpeg binary." >&2
+  exit 1
 else
   echo "Unsupported OS: $OS" >&2
   exit 1
@@ -40,13 +63,8 @@ TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
 echo "Downloading ffmpeg from $ASSET_URL"
-if [[ "$ASSET_URL" == *.zip ]]; then
-  curl -fsSL "$ASSET_URL" -o "$TMP_DIR/ffmpeg.zip"
-  unzip -q "$TMP_DIR/ffmpeg.zip" -d "$TMP_DIR"
-else
-  curl -fsSL "$ASSET_URL" -o "$TMP_DIR/ffmpeg.tar.xz"
-  tar -xJf "$TMP_DIR/ffmpeg.tar.xz" -C "$TMP_DIR"
-fi
+curl -fsSL "$ASSET_URL" -o "$TMP_DIR/ffmpeg.tar.xz"
+tar -xJf "$TMP_DIR/ffmpeg.tar.xz" -C "$TMP_DIR"
 FFMPEG_BIN="$(find "$TMP_DIR" -type f -name ffmpeg | head -n 1)"
 if [[ -z "${FFMPEG_BIN:-}" ]]; then
   echo "Could not find ffmpeg binary in downloaded archive" >&2

--- a/scripts/setup_yt_dlp.sh
+++ b/scripts/setup_yt_dlp.sh
@@ -7,18 +7,27 @@ TARGET_PATH="${AIRWAVE_YT_DLP_PATH:-$BIN_DIR/yt-dlp}"
 mkdir -p "$(dirname "$TARGET_PATH")"
 
 ARCH="$(uname -m)"
-case "$ARCH" in
-  x86_64|amd64) ASSET="yt-dlp_linux" ;;
-  aarch64|arm64) ASSET="yt-dlp_linux_aarch64" ;;
-  *)
-    echo "Unsupported architecture: $ARCH" >&2
-    exit 1
-    ;;
-esac
+OS="$(uname -s)"
+if [[ "$OS" == "Linux" ]]; then
+  case "$ARCH" in
+    x86_64|amd64) ASSET="yt-dlp_linux" ;;
+    aarch64|arm64) ASSET="yt-dlp_linux_aarch64" ;;
+    *)
+      echo "Unsupported architecture: $ARCH" >&2
+      exit 1
+      ;;
+  esac
+elif [[ "$OS" == "Darwin" ]]; then
+  # yt-dlp publishes a universal macOS executable named `yt-dlp_macos`.
+  ASSET="yt-dlp_macos"
+else
+  echo "Unsupported OS: $OS" >&2
+  exit 1
+fi
 
 DOWNLOAD_URL="https://github.com/yt-dlp/yt-dlp/releases/latest/download/${ASSET}"
 echo "Downloading yt-dlp from ${DOWNLOAD_URL}"
-curl -fsSL "$DOWNLOAD_URL" -o "$TARGET_PATH"
+curl -fsSL -L --retry 3 --retry-delay 2 "$DOWNLOAD_URL" -o "$TARGET_PATH"
 chmod +x "$TARGET_PATH"
 "$TARGET_PATH" --version
 echo "Installed yt-dlp to $TARGET_PATH"


### PR DESCRIPTION
- Updated `run_dev.sh` to retry frontend build after npm install if the initial build fails.
- Modified `setup_ffmpeg.sh` to prefer existing ffmpeg installations on macOS and added Homebrew installation fallback.
- Improved `setup_yt_dlp.sh` to support universal macOS executable and added retry logic for downloading yt-dlp.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced development build script with automatic error recovery: failed builds now trigger dependency reinstallation and retry instead of failing immediately.
  * Simplified macOS dependency setup: now checks for existing installations before attempting alternative installation methods.
  * Added robust download reliability: setup scripts now include automatic retries and redirect handling for improved installation stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->